### PR TITLE
Redirect landing page to threads view

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ VERCEL_PROTECTION_BYPASS=your_protection_bypass_token_here
 
 ## Deployment
 
-Your API is deployed at: https://track-set4.vercel.app/
+The API is deployed at: https://track-set4.vercel.app/

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,11 @@
 {
+    "redirects": [
+      {
+        "source": "/",
+        "destination": "/api/decisions-ui",
+        "permanent": false
+      }
+    ],
     "functions": {
       "api/*.js": {
         "maxDuration": 10


### PR DESCRIPTION
## Summary
- Added redirect in vercel.json to send root path "/" directly to the threads/decisions view at "/api/decisions-ui"
- Users will now skip the info landing page and go straight to viewing their threads

## Test plan
- [ ] Deploy to Vercel preview environment
- [ ] Verify that visiting the root URL redirects to /api/decisions-ui
- [ ] Ensure the redirect works correctly and shows the threads view

🤖 Generated with [Claude Code](https://claude.ai/code)