### PR TITLE
Remove debug navigation links from frontend UI

### DIFF
--- a/api/decisions-ui.js
+++ b/api/decisions-ui.js
@@ -85,10 +85,6 @@ export default async function handler(req, res) {
         </style>
       </head>
       <body>
-        <div class="nav">
-          <a href="/api/debug">🔧 Debug</a>
-        </div>
-        
         <div class="header">
           <h1>📋 Decision Log ${config.isProduction ? '' : `(${config.environment})`}</h1>
           ${!config.isProduction ? `

--- a/api/index.js
+++ b/api/index.js
@@ -77,10 +77,6 @@ export default async function handler(req, res) {
         </style>
       </head>
       <body>
-        <div class="nav">
-          <a href="/api/debug-decisions">🔧 Debug</a>
-        </div>
-        
         <div class="header">
           <h1>📋 Decision Log</h1>
           <div class="stats">


### PR DESCRIPTION
## Summary
- Removed debug navigation links from the decision log UI for cleaner production interface

## Changes
- Removed debug navigation div from `/api/decisions-ui.js` 
- Removed debug navigation div from `/api/index.js`
- No other functionality affected

## Testing
- Verified the UI renders correctly without the debug links
- All other functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)