### PR TITLE
Add remove button to decision tiles

### DIFF
--- a/api/delete-decision.js
+++ b/api/delete-decision.js
@@ -1,0 +1,33 @@
+import { sql } from '../lib/database.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'DELETE') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const { id } = req.query;
+    
+    if (!id) {
+      return res.status(400).json({ error: 'Decision ID required' });
+    }
+
+    const result = await sql`
+      DELETE FROM decisions 
+      WHERE id = ${id}
+      RETURNING id, decision_summary
+    `;
+    
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Decision not found' });
+    }
+    
+    res.status(200).json({ 
+      success: true, 
+      deleted: result.rows[0] 
+    });
+  } catch (error) {
+    console.error('Delete error:', error);
+    res.status(500).json({ error: error.message });
+  }
+}


### PR DESCRIPTION
## Summary
- Added ability to remove irrelevant or incorrect decision threads from the UI and database
- Implemented secure deletion with confirmation dialog
- Added smooth animations for better UX

## Changes
- Created new `/api/delete-decision` endpoint that handles DELETE requests
- Added red remove button (×) to each decision tile that appears on hover
- Implemented client-side confirmation before deletion
- Added fade-out animation when removing tiles
- Auto-reloads page when all decisions are removed to show empty state

## Test plan
- [x] Test remove button appears on hover
- [x] Test confirmation dialog works
- [x] Test decision is removed from UI with animation
- [x] Test decision is deleted from database
- [x] Test page reloads when last decision is removed
- [x] Test error handling for failed deletions

🤖 Generated with [Claude Code](https://claude.ai/code)